### PR TITLE
Fix tests by importing subprocess

### DIFF
--- a/tests/test_adb.py
+++ b/tests/test_adb.py
@@ -1,5 +1,6 @@
 import unittest
 from unittest.mock import patch
+import subprocess
 from backend.utils.adb import ADB  # Zaktualizowana ścieżka importu
 
 class TestADB(unittest.TestCase):


### PR DESCRIPTION
## Summary
- fix `tests/test_adb.py` by adding a missing `subprocess` import

## Testing
- `python run_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_685dc90bca60832facd1834ee208a81d