### PR TITLE
Fix tests by importing subprocess

### DIFF
--- a/tests/test_adb.py
+++ b/tests/test_adb.py
@@ -1,4 +1,5 @@
 import unittest
+import subprocess
 from unittest.mock import patch
 from backend.utils.adb import ADB  # Zaktualizowana ścieżka importu
 


### PR DESCRIPTION
## Summary
- fix missing import of subprocess in tests/test_adb.py

## Testing
- `python3 run_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_685dcdd7ade8832faa9fc22f1cdadb8f